### PR TITLE
Replace bash specific wildcard representation with general wildcard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,11 @@ pywrapper:
 	((cd py && $(ECHO) 'import extreme_deconvolution' | $(PYTHON)) && $(ECHO) 'Successfully installed Python wrapper' || ($(ECHO) 'Something went wrong installing Python wrapper' && exit -1))
 
 rpackage:
-	cp src/{*.h,*.c} r/src
+	cp src/*.h src/*.c r/src
 	patch r/src/proj_gauss_mixtures_IDL.c < r/src/proj_gauss_mixtures_R.patch
 	R CMD check r --no-manual -o $(shell mktemp -d tmp.XXXX)
 	R CMD build r --no-manual
-	rm -f r/src/{*.h,*.c}
+	rm -f r/src/*.h r/src/*.c
 	((R CMD INSTALL ExtremeDeconvolution_*.tar.gz -l $(shell echo "cat(.libPaths()[1])" | R --slave) && rm -rf tmp.*) || ($(ECHO) "Please install the package manually with proper library path specified, e.g., R CMD INSTALL ExtremeDeconvolution_<version>.tar.gz -l /path/to/your/R/library/directory"))
 #
 # TEST THE INSTALLATION


### PR DESCRIPTION
On Debian Linux version 8 (latest stable) the default shell for Makefile is not bash. This patch removed bash specific syntax.