### PR TITLE
Updates to the `ycovar` on the R interface

### DIFF
--- a/r/R/extreme_deconvolution.R
+++ b/r/R/extreme_deconvolution.R
@@ -18,9 +18,11 @@ extreme_deconvolution <- function(ydata, ycovar, xamp, xmean, xcovar, projection
     dataDim <- dim(ydata)[2]
     ngauss <- length(xamp)
     gaussDim <- dim(xmean)[2]
-    if (is.null(dim(ycovar))) {
+    if (length(dim(ycovar)) > 2) {
+        tycovar <- apply(ycovar, 3, t)
         diagerrors <- FALSE
     } else {
+        tycovar <- t(ycovar)
         diagerrors <- TRUE
     }
     fixamp <- .fixfix(fixamp, ngauss)
@@ -59,7 +61,7 @@ extreme_deconvolution <- function(ydata, ycovar, xamp, xmean, xcovar, projection
         logweights <- weight
     }
     # 
-    res <- .C("proj_gauss_mixtures_IDL", as.double(as.vector(t(ydata))), as.double(as.vector(t(ycovar))), 
+    res <- .C("proj_gauss_mixtures_IDL", as.double(as.vector(t(ydata))), as.double(as.vector(tycovar)),
         as.double(as.vector(unlist(lapply(projection, t)))), as.double(as.vector(logweights)), 
         as.integer(ndata), as.integer(dataDim), xamp = as.double(as.vector(t(xamp))), 
         xmean = as.double(as.vector(t(xmean))), xcovar = as.double(as.vector(unlist(lapply(xcovar, 

--- a/r/R/extreme_deconvolution.R
+++ b/r/R/extreme_deconvolution.R
@@ -18,10 +18,14 @@ extreme_deconvolution <- function(ydata, ycovar, xamp, xmean, xcovar, projection
     dataDim <- dim(ydata)[2]
     ngauss <- length(xamp)
     gaussDim <- dim(xmean)[2]
-    if (length(dim(ycovar)) > 2) {
+    if (typeof(ycovar) == "list") {
+        tycovar <- unlist(lapply(ycovar, t))
+        diagerrors <- FALSE
+    } else if (length(dim(ycovar)) == 3) {
         tycovar <- apply(ycovar, 3, t)
         diagerrors <- FALSE
     } else {
+        # a matrix
         tycovar <- t(ycovar)
         diagerrors <- TRUE
     }

--- a/r/man/extreme_deconvolution.rd
+++ b/r/man/extreme_deconvolution.rd
@@ -16,7 +16,7 @@ extreme_deconvolution(ydata,ycovar,
 
 \arguments{
   \item{ydata}{[ndata,dy] matrix of observed quantities}
-  \item{ycovar}{[ndata,dy] / [dy,dy,ndata] matrix or 3D array
+  \item{ycovar}{[ndata,dy] / [ndata,dy,dy] / [dy,dy,ndata] matrix, list or 3D array
     of observational error covariances
     (if [ndata,dy] then the error correlations are assumed to vanish)}
   \item{xamp}{[ngauss] array of initial amplitudes (*not* [1,ngauss])}

--- a/r/man/extreme_deconvolution.rd
+++ b/r/man/extreme_deconvolution.rd
@@ -16,8 +16,9 @@ extreme_deconvolution(ydata,ycovar,
 
 \arguments{
   \item{ydata}{[ndata,dy] matrix of observed quantities}
-  \item{ycovar}{[ndata,dy(,dy)] matrix of observational error covariances
-                (if [ndata,dy] then the error correlations are assumed to vanish)}
+  \item{ycovar}{[ndata,dy] / [dy,dy,ndata] matrix or 3D array
+    of observational error covariances
+    (if [ndata,dy] then the error correlations are assumed to vanish)}
   \item{xamp}{[ngauss] array of initial amplitudes (*not* [1,ngauss])}
   \item{xmean}{[ngauss,dx] matrix of initial means}
   \item{xcovar}{[ngauss,dx,dx] list of matrices of initial covariances}

--- a/src/proj_gauss_mixtures_IDL.c
+++ b/src/proj_gauss_mixtures_IDL.c
@@ -47,7 +47,7 @@ int proj_gauss_mixtures_IDL(double * ydata, double * ycovar,
     for (ss = 0; ss != convloglen; ++ss)
       convlogname[ss] = (char) *(convlogfilename++);
     logfilename -= slen;
-    convlogfilename -= slen;
+    convlogfilename -= convloglen;
     logname[slen] = '\0';
     convlogname[convloglen] = '\0';
   }


### PR DESCRIPTION
This is a bug fix -- previously I have not tested the outcome of feeding `ycovar` as a 3D array to the R interface. Turns out to be not as straightforwards as with Python. Just fixed it.